### PR TITLE
No global internal imports

### DIFF
--- a/docs/rules/no-deep-module-imports.md
+++ b/docs/rules/no-deep-module-imports.md
@@ -22,7 +22,3 @@ Examples of **correct** code for this rule:
 import { Something } from 'modules/myModule';
 
 ```
-
-### Options
-
-If there are any options, describe them here. Otherwise, delete this section.

--- a/docs/rules/no-global-internal-imports.md
+++ b/docs/rules/no-global-internal-imports.md
@@ -1,0 +1,24 @@
+# Disallow global paths for internal module dependancies (no-global-internal-imports)
+
+This rule prevents importing local module level dependencies via global module path. Relative imports should be used instead.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+// file path: modules/myModule/file.js
+import { Something } from 'modules/myModule/internal.js';
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// file path: modules/myModule/file.js
+import { Something } from './internal.js';
+
+```

--- a/lib/rules/enforce-hierarchy.js
+++ b/lib/rules/enforce-hierarchy.js
@@ -31,10 +31,9 @@ module.exports = {
     },
 
     create: function (context) {
-        const {resolve, stripCwd, getCategories, findCategory} = createUtils(context.getCwd(), context.settings.htg);
+        const {resolve, stripCwd, findCategory} = createUtils(context.getCwd(), context.settings.htg);
 
         const options = context.options[0];
-        const categories = getCategories();
 
         //----------------------------------------------------------------------
         // Helpers
@@ -58,10 +57,10 @@ module.exports = {
                 const importPath = resolve(source.value);
                 const filePath = context.getFilename();
 
-                const importCategory = findCategory(categories, importPath);
+                const importCategory = findCategory(importPath);
                 if (!importCategory) return;
 
-                const fileCategory = findCategory(categories, filePath);
+                const fileCategory = findCategory(filePath);
                 if (!fileCategory) return;
 
                 if (importCategory === fileCategory) return;
@@ -70,7 +69,7 @@ module.exports = {
                 if (isAllowed) return;
 
                 context.report({
-                    node: node,
+                    node: node.source,
                     message: `HTG: Importing from forbidden module category: {{ sourceModule }} -> {{ targetModule }}.`,
                     data: {
                         sourceModule: stripCwd(fileCategory),

--- a/lib/rules/no-deep-module-imports.js
+++ b/lib/rules/no-deep-module-imports.js
@@ -20,9 +20,7 @@ module.exports = {
     },
 
     create: function (context) {
-        const {resolve, getCategories, findModule, stripCwd} = createUtils(context.getCwd(), context.settings.htg);
-
-        const categories = getCategories();
+        const {resolve, findModule} = createUtils(context.getCwd(), context.settings.htg);
 
         //----------------------------------------------------------------------
         // Helpers
@@ -41,17 +39,17 @@ module.exports = {
                 const importPath = resolve(source.value);
                 const filePath = context.getFilename();
 
-                const importModule = findModule(categories, importPath);
+                const importModule = findModule(importPath);
                 if (!importModule) return;
 
-                const fileModule = findModule(categories, filePath);
+                const fileModule = findModule(filePath);
                 if (importModule === fileModule) return;
 
                 const isReaching = isReachingIntoModule(importPath, importModule);
                 if (!isReaching) return;
 
                 context.report({
-                    node: node,
+                    node: node.source,
                     message: `HTG: Reaching deep into the module. Use modules public interface.`,
                 });
             }

--- a/lib/rules/no-global-internal-imports.js
+++ b/lib/rules/no-global-internal-imports.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const {createUtils} = require('../utils');
+const {createUtils, getRelativePath} = require('../utils');
+const path = require('path');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -46,11 +47,20 @@ module.exports = {
                 node: node.source,
                 message: errorMessage,
                 fix: function(fixer) {
-                    if (importPath === fileModule) return; // Importing via module public interface. Need manually to check what thing is being imported and use internal path.
-                    return fixer.replaceText(node.source, node.source.raw.replace(node.source.value, `.${importPath.replace(fileModule, '')}`));
+                    if (importPath === fileModule) return; // Importing via module public interface. Not autofixable. Need manually to check what thing is being imported and use internal path.
+
+                    // node.source.raw: "@modules/myModule/file.js"
+                    // node.source.value: @modules/myModule/file.js
+
+                    return fixer.replaceText(
+                        node.source,
+                        node.source.raw.replace(
+                            node.source.value,
+                            getRelativePath(filePath, importPath)
+                        )
+                    );
                 }
             });
-            //[print(node), print(node.source)].join(';\n')
         }
 
         //----------------------------------------------------------------------

--- a/lib/rules/no-global-internal-imports.js
+++ b/lib/rules/no-global-internal-imports.js
@@ -13,22 +13,18 @@ module.exports = {
             category: "Fill me in",
             recommended: false
         },
-        fixable: null,  // or "code" or "whitespace"
+        fixable: "code",
         schema: [
             // fill in your schema
         ]
     },
 
     create: function (context) {
-        const {resolve, getCategories, findModule, stripCwd} = createUtils(context.getCwd(), context.settings.htg);
-
-        const categories = getCategories();
+        const {resolve, findModule, stripCwd} = createUtils(context.getCwd(), context.settings.htg);
 
         //----------------------------------------------------------------------
         // Helpers
         //----------------------------------------------------------------------
-
-        const isReachingIntoModule = (importPath, module) => importPath.replace(module, '').split('/').length > 1;
 
         const createValidator = (errorMessage) => (node) => {
             const {source} = node;
@@ -37,19 +33,24 @@ module.exports = {
             const importPath = resolve(source.value);
             const filePath = context.getFilename();
 
-            const importModule = findModule(categories, importPath);
+            const importModule = findModule(importPath);
             if (!importModule) return;
 
-            const fileModule = findModule(categories, filePath);
+            const fileModule = findModule(filePath);
 
             if (importModule !== fileModule) return;
 
             if (importPath[0] === '.') return;
 
             context.report({
-                node: node,
+                node: node.source,
                 message: errorMessage,
+                fix: function(fixer) {
+                    if (importPath === fileModule) return; // Importing via module public interface. Need manually to check what thing is being imported and use internal path.
+                    return fixer.replaceText(node.source, node.source.raw.replace(node.source.value, `.${importPath.replace(fileModule, '')}`));
+                }
             });
+            //[print(node), print(node.source)].join(';\n')
         }
 
         //----------------------------------------------------------------------

--- a/lib/rules/no-global-internal-imports.js
+++ b/lib/rules/no-global-internal-imports.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const {createUtils} = require('../utils');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Enforce relative paths for local module files",
+            category: "Fill me in",
+            recommended: false
+        },
+        fixable: null,  // or "code" or "whitespace"
+        schema: [
+            // fill in your schema
+        ]
+    },
+
+    create: function (context) {
+        const {resolve, getCategories, findModule, stripCwd} = createUtils(context.getCwd(), context.settings.htg);
+
+        const categories = getCategories();
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        const isReachingIntoModule = (importPath, module) => importPath.replace(module, '').split('/').length > 1;
+
+        const createValidator = (errorMessage) => (node) => {
+            const {source} = node;
+            if (!source) return;
+
+            const importPath = resolve(source.value);
+            const filePath = context.getFilename();
+
+            const importModule = findModule(categories, importPath);
+            if (!importModule) return;
+
+            const fileModule = findModule(categories, filePath);
+
+            if (importModule !== fileModule) return;
+
+            if (importPath[0] === '.') return;
+
+            context.report({
+                node: node,
+                message: errorMessage,
+            });
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            ImportDeclaration: createValidator(`HTG: Importing local dependency via global path.`),
+            ExportNamedDeclaration: createValidator(`HTG: Exporting local dependency via global path.`),
+        };
+    }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,12 @@ const createUtils = (cwd, settings) => {
     return {resolve, stripCwd, getCategories, findCategory, findModule};
 }
 
+const getRelativePath = (from, to) => {
+    const prefix = path.relative(path.dirname(from), path.dirname(to)) || '.';
+    return (prefix[0] !== '.' ? './' : '') + `${prefix}/${path.basename(to)}`;
+}
+
 module.exports = {
-    createUtils
+    createUtils,
+    getRelativePath
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const createUtils = (cwd, settings) => {
     const resolve = (importPath) => {
         const aliases = Object.keys(settings.path);
@@ -8,17 +10,19 @@ const createUtils = (cwd, settings) => {
             importPath = importPath.replace(alias, settings.path[alias])
         }
 
-        return [cwd, importPath].join('/');
+        return path.resolve([cwd, importPath].join('/'));
     }
 
     const stripCwd = (path) => path.replace(cwd, '');
 
     const getCategories = () => settings.modules.map(value => resolve(value));
 
-    const findCategory = (modules, importPath) => modules.find(value => importPath.startsWith(value));
+    const findCategory = (importPath) => getCategories().find(value => importPath.startsWith(value));
 
-    const findModule = (modules, importPath) => {
-        const category = findCategory(modules, importPath);
+    const pathToAlias = (path) => stripCwd(path)
+
+    const findModule = (importPath) => {
+        const category = findCategory(importPath);
 
         if (!category) return;
 

--- a/tests/_utils.js
+++ b/tests/_utils.js
@@ -1,0 +1,20 @@
+const {createUtils} = require("../lib/utils");
+
+const parserOptions = {
+    ecmaVersion: 2015,
+    sourceType: 'module'
+};
+
+const createTest = (settings) => {
+    const utils = createUtils(process.cwd(), settings.htg);
+
+    return (t) => Object.assign(
+        {settings, parserOptions},
+        t,
+        {filename: utils.resolve(t.filename)}
+    );
+}
+
+module.exports = {
+    createTest
+};

--- a/tests/lib/rules/enforce-hierarchy.js
+++ b/tests/lib/rules/enforce-hierarchy.js
@@ -6,7 +6,7 @@
 
 var rule = require("../../../lib/rules/enforce-hierarchy"),
     RuleTester = require("eslint").RuleTester;
-const {createTest} = require("../utils");
+const {createTest} = require("../../_utils");
 
 const settings = {
     htg: {
@@ -70,7 +70,7 @@ ruleTester.run("enforce-hierarchy", rule, {
             options,
             errors: [{
                 message: "HTG: Importing from forbidden module category: /src/modules/features -> /src/modules/pages.",
-                type: "ImportDeclaration"
+                type: "Literal"
             }]
         })
     ]

--- a/tests/lib/rules/enforce-hierarchy.js
+++ b/tests/lib/rules/enforce-hierarchy.js
@@ -5,7 +5,6 @@
 //------------------------------------------------------------------------------
 
 var rule = require("../../../lib/rules/enforce-hierarchy"),
-
     RuleTester = require("eslint").RuleTester;
 const {createTest} = require("../utils");
 

--- a/tests/lib/rules/no-deep-module-imports.js
+++ b/tests/lib/rules/no-deep-module-imports.js
@@ -10,7 +10,6 @@ function testFilePath(relativePath) {
 }
 
 var rule = require("../../../lib/rules/no-deep-module-imports"),
-
     RuleTester = require("eslint").RuleTester;
 
 const {createTest} = require("../utils");

--- a/tests/lib/rules/no-deep-module-imports.js
+++ b/tests/lib/rules/no-deep-module-imports.js
@@ -12,7 +12,7 @@ function testFilePath(relativePath) {
 var rule = require("../../../lib/rules/no-deep-module-imports"),
     RuleTester = require("eslint").RuleTester;
 
-const {createTest} = require("../utils");
+const {createTest} = require("../../_utils");
 
 const settings = {
     htg: {
@@ -67,7 +67,7 @@ ruleTester.run("no-deep-module-imports", rule, {
             filename: "@modules/commons/anotherModule/MyFile.js",
             errors: [{
                 message: "HTG: Reaching deep into the module. Use modules public interface.",
-                type: "ImportDeclaration"
+                type: "Literal"
             }]
         }),
         test({ // Deep import from non-module into module
@@ -75,7 +75,7 @@ ruleTester.run("no-deep-module-imports", rule, {
             filename: "src/my/custom/very/very/deep/MyAnotherFile.js",
             errors: [{
                 message: "HTG: Reaching deep into the module. Use modules public interface.",
-                type: "ImportDeclaration"
+                type: "Literal"
             }]
         }),
     ]

--- a/tests/lib/rules/no-global-internal-imports.js
+++ b/tests/lib/rules/no-global-internal-imports.js
@@ -1,0 +1,86 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+const path = require('path');
+
+function testFilePath(relativePath) {
+    return path.join(process.cwd(), './tests/files', relativePath)
+}
+
+var rule = require("../../../lib/rules/no-global-internal-imports"),
+    RuleTester = require("eslint").RuleTester;
+
+const {createTest} = require("../utils");
+
+const settings = {
+    htg: {
+        path: {
+            '@modules/': 'src/modules/'
+        },
+        modules: [
+            '@modules/commons',
+            '@modules/models',
+            '@modules/components',
+            '@modules/features',
+            '@modules/pages',
+        ]
+    }
+};
+
+const test = createTest(settings);
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-global-internal-imports", rule, {
+
+    valid: [
+        test({ // Import into another module from public interface
+            code: "import { fn } from '@modules/commons/module'",
+            filename: "@modules/commons/anotherModule/SomeFile.js",
+        }),
+        test({ // Import from simple file
+            code: "import { fn } from '@modules/commons/module'",
+            filename: "simpleFile.js",
+        }),
+        test({ // Import rellative file in same module
+            code: "import { fn } from './utils.js'",
+            filename: "@modules/commons/module/SomeFile.js",
+        }),
+        test({ // exporting a variable value
+            code: "export const variable = 'value'",
+            filename: "@modules/commons/module/SomeFile.js",
+        }),
+    ],
+
+    invalid: [
+        test({ // Importing local file via global path
+            code: "import { fn } from '@modules/commons/module/utils.js'",
+            filename: "@modules/commons/module/SomeFile.js",
+            errors: [{
+                message: "HTG: Importing local dependency via global path.",
+                type: "ImportDeclaration"
+            }]
+        }),
+        test({ // Exporting local file via global path
+            code: "export { fn } from '@modules/commons/module/utils.js'",
+            filename: "@modules/commons/module/index.js",
+            errors: [{
+                message: "HTG: Exporting local dependency via global path.",
+                type: "ExportNamedDeclaration"
+            }]
+        }),
+        test({ // Importing local file via global path
+            code: "import { fn } from '@modules/commons/module'",
+            filename: "@modules/commons/module/SomeFile.js",
+            errors: [{
+                message: "HTG: Importing local dependency via global path.",
+                type: "ImportDeclaration"
+            }]
+        }),
+    ]
+});

--- a/tests/lib/rules/no-global-internal-imports.js
+++ b/tests/lib/rules/no-global-internal-imports.js
@@ -12,7 +12,7 @@ function testFilePath(relativePath) {
 var rule = require("../../../lib/rules/no-global-internal-imports"),
     RuleTester = require("eslint").RuleTester;
 
-const {createTest} = require("../utils");
+const {createTest} = require("../../_utils");
 
 const settings = {
     htg: {
@@ -63,23 +63,34 @@ ruleTester.run("no-global-internal-imports", rule, {
             filename: "@modules/commons/module/SomeFile.js",
             errors: [{
                 message: "HTG: Importing local dependency via global path.",
-                type: "ImportDeclaration"
-            }]
+                type: "Literal"
+            }],
+            output: "import { fn } from './utils.js'",
+        }),
+        test({ // Importing local deeply nested file via global path
+            code: "import { fn } from '@modules/commons/module/a/b/c/utils.js'",
+            filename: "@modules/commons/module/SomeFile.js",
+            errors: [{
+                message: "HTG: Importing local dependency via global path.",
+                type: "Literal"
+            }],
+            output: "import { fn } from './a/b/c/utils.js'",
         }),
         test({ // Exporting local file via global path
             code: "export { fn } from '@modules/commons/module/utils.js'",
             filename: "@modules/commons/module/index.js",
             errors: [{
                 message: "HTG: Exporting local dependency via global path.",
-                type: "ExportNamedDeclaration"
-            }]
+                type: "Literal"
+            }],
+            output: "export { fn } from './utils.js'"
         }),
-        test({ // Importing local file via global path
+        test({ // Importing local file via global public file
             code: "import { fn } from '@modules/commons/module'",
             filename: "@modules/commons/module/SomeFile.js",
             errors: [{
                 message: "HTG: Importing local dependency via global path.",
-                type: "ImportDeclaration"
+                type: "Literal"
             }]
         }),
     ]

--- a/tests/lib/rules/no-global-internal-imports.js
+++ b/tests/lib/rules/no-global-internal-imports.js
@@ -76,6 +76,24 @@ ruleTester.run("no-global-internal-imports", rule, {
             }],
             output: "import { fn } from './a/b/c/utils.js'",
         }),
+        test({ // Importing local file from deeply nested local file via global path
+            code: "import { fn } from '@modules/commons/module/rootfile.js'",
+            filename: "@modules/commons/module/subfolder/subfile.js",
+            errors: [{
+                message: "HTG: Importing local dependency via global path.",
+                type: "Literal"
+            }],
+            output: "import { fn } from '../rootfile.js'",
+        }),
+        test({ // Importing local deeply nested file from another deeply nested local file via global path
+            code: "import { fn } from '@modules/commons/module/subfolder/subfile1.js'",
+            filename: "@modules/commons/module/subfolder/subfile2.js",
+            errors: [{
+                message: "HTG: Importing local dependency via global path.",
+                type: "Literal"
+            }],
+            output: "import { fn } from './subfile1.js'",
+        }),
         test({ // Exporting local file via global path
             code: "export { fn } from '@modules/commons/module/utils.js'",
             filename: "@modules/commons/module/index.js",

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {createUtils} = require('../../lib/utils');
+const {createUtils, getRelativePath} = require('../../lib/utils');
 
 describe('createUtils', function () {
     let utils;
@@ -100,5 +100,28 @@ describe('createUtils', function () {
 
             assert.strictEqual(result,undefined);
         });
+    });
+});
+
+describe('getRelativePath', function () {
+    it('should return relative path for files in different directories', function () {
+        const result = getRelativePath('/a/b/c/d.js', '/a/b/x/y.js');
+
+        assert.strictEqual(result,'../x/y.js');
+    });
+    it('should return relative path for files in same directory', function () {
+        const result = getRelativePath('/a/x.js', '/a/y.js');
+
+        assert.strictEqual(result,'./y.js');
+    });
+    it('should return relative path to deeply nested directory', function () {
+        const result = getRelativePath('/d.js', '/a/b/x/y.js');
+
+        assert.strictEqual(result,'./a/b/x/y.js');
+    });
+    it('should return relative path to root of directory', function () {
+        const result = getRelativePath('/a/b/x/y.js', '/d.js');
+
+        assert.strictEqual(result,'../../../d.js');
     });
 });

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -1,20 +1,104 @@
-const {createUtils} = require("../../lib/utils");
+const assert = require('assert');
+const {createUtils} = require('../../lib/utils');
 
-const parserOptions = {
-    ecmaVersion: 2015,
-    sourceType: 'module'
-};
+describe('createUtils', function () {
+    let utils;
 
-const createTest = (settings) => {
-    const utils = createUtils(process.cwd(), settings.htg);
+    beforeEach(() => {
+        utils = createUtils('/root', {
+                path: {
+                    '@modules/': 'src/modules/'
+                },
+                modules: [
+                    '@modules/commons',
+                    '@modules/models',
+                    '@modules/components',
+                    '@modules/features',
+                    '@modules/pages',
+                ]
+            }
+        );
+    });
 
-    return (t) => Object.assign(
-        {settings, parserOptions},
-        t,
-        {filename: utils.resolve(t.filename)}
-    );
-}
+    describe('resolve', function () {
+        it('should resolve aliased path', function () {
+            const result = utils.resolve('@modules/models/module/file.js');
 
-module.exports = {
-    createTest
-};
+            assert.strictEqual(result, '/root/src/modules/models/module/file.js');
+        });
+
+        it('should resolve regular file path', function () {
+            const result = utils.resolve('src/a/b/file.js');
+
+            assert.strictEqual(result, '/root/src/a/b/file.js');
+        });
+
+        it('should resolve navigating to parent dir', function () {
+            const result = utils.resolve('../src/a/b/file.js');
+
+            assert.strictEqual(result, '/src/a/b/file.js');
+        });
+
+        it('should resolve current dir', function () {
+            const result = utils.resolve('./src/a/b/file.js');
+
+            assert.strictEqual(result, '/root/src/a/b/file.js');
+        });
+    });
+
+    describe('stripCwd', function () {
+        it('should remove CWD from path', function () {
+            const result = utils.stripCwd('/root/src/modules/models/module/file.js');
+
+            assert.strictEqual(result, '/src/modules/models/module/file.js');
+        });
+
+        it('should keep path intact if it is not global', function () {
+            const result = utils.stripCwd('src/a/b/file.js');
+
+            assert.strictEqual(result, 'src/a/b/file.js');
+        });
+    });
+
+    describe('getCategories', function () {
+        it('should return categories with absolute paths', function () {
+            const result = utils.getCategories();
+
+            assert.deepStrictEqual(result, [
+                '/root/src/modules/commons',
+                '/root/src/modules/models',
+                '/root/src/modules/components',
+                '/root/src/modules/features',
+                '/root/src/modules/pages'
+            ]);
+        });
+    });
+
+    describe('findCategory', function () {
+        it('should return absolute path to the category', function () {
+            const result = utils.findCategory('/root/src/modules/pages/a/index.js');
+
+            assert.strictEqual(result,'/root/src/modules/pages');
+        });
+
+        it('should return undefined if path is not part of cateogry', function () {
+            const result = utils.findCategory('/root/src/a/b/c/index.js');
+
+            assert.strictEqual(result,undefined);
+        });
+    });
+
+    describe('findModule', function () {
+        it('should return absolute path to the module', function () {
+            const result = utils.findModule('/root/src/modules/pages/a/index.js');
+
+            assert.strictEqual(result,'/root/src/modules/pages/a');
+        });
+
+        it('should return undefined if path is not part of module', function () {
+            const result = utils.findModule('/root/src/a/b/c/index.js');
+
+            assert.strictEqual(result,undefined);
+        });
+    });
+});


### PR DESCRIPTION
- Add a new `no-global-internal-imports` rule with auto-fix. It enforces global paths for external modules and relative paths for internal module files.
- Cover utils with unit tests
- Fix rules to mark actual import path as wrong instead of simply import keyword.
