### PR TITLE
no-own-index-imports rule

### DIFF
--- a/lib/rules/no-own-index-imports.js
+++ b/lib/rules/no-own-index-imports.js
@@ -1,0 +1,46 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Prevent imports from modules own index files",
+            recommended: false,
+        },
+        schema: []
+    },
+
+    create: function (context) {
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        const invalidImports = [
+            '.',
+            './',
+            './index'
+        ]
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+
+            ImportDeclaration: (node) => {
+                if (!node.source) return;
+
+                if (invalidImports.indexOf(node.source.value) === -1) return;
+    
+                context.report({
+                    node: node.source,
+                    message: 'HTG: importing from module\'s own index file. Convert to a relative import.',
+                });
+            }
+        };
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-htg",
-  "version": "0.0.0",
+  "version": "1.2.0",
   "description": "HTG eslint plugin",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-own-index-imports.js
+++ b/tests/lib/rules/no-own-index-imports.js
@@ -1,0 +1,70 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+var rule = require("../../../lib/rules/no-own-index-imports"),
+    RuleTester = require("eslint").RuleTester;
+
+const {createTest} = require("../../_utils");
+
+const test = createTest({
+    htg: {
+        path: {
+            '@modules/': 'src/modules/'
+        },
+        modules: [
+            '@modules/libs',
+        ]
+    }
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-own-index-imports", rule, {
+
+    valid: [
+        test({
+            code: "import { fn } from './OtherFile'",
+            filename: "@modules/libs/someModule/SomeFile.js",
+        }),
+        test({
+            code: "import { fn } from '@modules/libs/otherModule'",
+            filename: "@modules/libs/someModule/SomeFile.js",
+        }),
+        test({
+            code: "import { fn } from '@modules/libs/otherModule/index'",
+            filename: "@modules/libs/someModule/SomeFile.js",
+        }),
+    ],
+
+    invalid: [
+        test({
+            code: "import { fn } from '.'",
+            filename: "@modules/libs/someModule/SomeFile.js",
+            errors: [{
+                message: "HTG: importing from module\'s own index file. Convert to a relative import.",
+                type: "Literal"
+            }]
+        }),
+        test({
+            code: "import { fn } from './'",
+            filename: "@modules/libs/someModule/SomeFile.js",
+            errors: [{
+                message: "HTG: importing from module\'s own index file. Convert to a relative import.",
+                type: "Literal"
+            }]
+        }),
+        test({
+            code: "import { fn } from './index'",
+            filename: "@modules/libs/someModule/SomeFile.js",
+            errors: [{
+                message: "HTG: importing from module\'s own index file. Convert to a relative import.",
+                type: "Literal"
+            }]
+        })
+    ]
+});


### PR DESCRIPTION
Rule prevents modules to import from `index` file in the same module because such imports create circular references