### PR TITLE
Disallow imports between wildcarded categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Define path aliases for import resolution.
 
 Provide an array of paths to directories containing modules.
 
+### Wildcards
+
+Wildcards are supported in the paths, but support for now is minimal:
+- Only a single wildcard is supported:
+    - Supported: `apps/*/features`
+    - Not Supported: `apps/*/features/*/components`
+- Wildcards does not support partial directory matching:
+    - Supported: `apps/*/features`
+    - Not Supported: `apps/prefix_*/features`
+
+Note: Primary use for wildcards is to separate different applications. Imports between different applications are forbidden.
+
 ## Rules
 
 ### [`htg/enforce-hierarchy`](docs/rules/enforce-hierarchy.md)

--- a/README.md
+++ b/README.md
@@ -71,18 +71,19 @@ Define path aliases for import resolution.
 
 Provide an array of paths to directories containing modules.
 
-### Wildcards
+### Wildcards for multi app support
 
-Wildcards are supported in the paths, but support for now is minimal:
+Primary use for wildcards is to separate different applications.
+Imports between different applications are forbidden.
+
+Wildcard support is minimal:
 - Only a single wildcard is supported:
     - Supported: `apps/*/features`
-    - Not Supported: `apps/*/features/*/components`
+    - Not Supported: `apps/*/subapps/*/features`
 - Wildcards does not support partial directory matching:
     - Supported: `apps/*/features`
     - Not Supported: `apps/prefix_*/features`
-
-Note: Primary use for wildcards is to separate different applications. Imports between different applications are forbidden.
-
+    
 ## Rules
 
 ### [`htg/enforce-hierarchy`](docs/rules/enforce-hierarchy.md)

--- a/lib/rules/enforce-hierarchy.js
+++ b/lib/rules/enforce-hierarchy.js
@@ -64,17 +64,18 @@ module.exports = {
                 const sourceCategory = findCategory(source);
                 if (!sourceCategory) return;
 
-                if (targetCategory === sourceCategory) return;
+                if (source.wildcard === target.wildcard) {
+                    if (targetCategory === sourceCategory) return;
 
-                const isAllowed = isDependencyAllowed(sourceCategory, targetCategory);
-                if (isAllowed) return;
+                    if (isDependencyAllowed(sourceCategory, targetCategory)) return;
+                }
 
                 context.report({
                     node: node.source,
                     message: `HTG: Importing from forbidden module category: {{ sourceModule }} -> {{ targetModule }}.`,
                     data: {
-                        sourceModule: stripCwd(sourceCategory),
-                        targetModule: stripCwd(targetCategory)
+                        sourceModule: stripCwd(sourceCategory).replace('*', source.wildcard),
+                        targetModule: stripCwd(targetCategory).replace('*', target.wildcard)
                     }
                 });
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,9 @@ const createUtils = (cwd, settings) => {
             importPath = importPath.replace(alias, settingsPath[alias])
         }
 
-        return path.resolve([cwd, importPath].join('/'));
+        return importPath[0] === '/'
+            ? importPath
+            : path.resolve([cwd, importPath].join('/'));
     }
 
     // Basic wildcard matcher. Supports only `apps/*/features`. Does not support neither `apps/prefix_*/features` nor `apps/*/features/*/subfeatures`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,15 @@ const createUtils = (cwd, settings) => {
         return path.resolve([cwd, importPath].join('/'));
     }
 
+    // Basic wildcard matcher. Supports only `apps/*/features`. Does not support neither `apps/prefix_*/features` nor `apps/*/features/*/subfeatures`
+    const getWildcard = (path, realPath) => {
+        const parts = path.split('*');
+
+        if (parts.length === 1) return;
+
+        return realPath.replace(parts[0], '').split('/')[0];
+    }
+
     const resolve = (raw, sourceFile) => {
         let realPath;
 
@@ -32,20 +41,31 @@ const createUtils = (cwd, settings) => {
             realPath = resolveFullPath(raw);
         }
 
-        return {
-            raw,
-            realPath,
-            path: pathToVirtual(realPath)
-        }
+        const virtualPath = pathToVirtual(realPath);
+
+        return createFileObject(raw, realPath, virtualPath);
     }
 
     const resolveFromFullPath = (raw) => {
         if (raw[0] !== '/') throw new Error(`resolveFromFullPath: Not a full path "${raw}"`);
-        return {
+
+        const virtualPath = pathToVirtual(raw);
+
+        return createFileObject(raw, raw, virtualPath);
+    }
+
+    const createFileObject = (raw, realPath, path) => {
+        const wildcard = getWildcard(path, realPath);
+
+        const response = {
             raw,
-            realPath: raw,
-            path: pathToVirtual(raw)
-        }
+            realPath,
+            path
+        };
+
+        if (wildcard) response.wildcard = wildcard;
+
+        return response;
     }
 
     const sortByPathDepth = (a, b) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-htg",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "HTG eslint plugin",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/enforce-hierarchy.js
+++ b/tests/lib/rules/enforce-hierarchy.js
@@ -76,7 +76,16 @@ ruleTester.run("enforce-hierarchy", rule, {
             filename: "@modules/apps/demo/libs/unitCard/DesktopComponent.tsx",
             options,
             errors: [{
-                message: "HTG: Importing from forbidden module category: /src/modules/apps/*/libs -> /src/modules/features.",
+                message: "HTG: Importing from forbidden module category: /src/modules/apps/demo/libs -> /src/modules/features.",
+                type: "Literal"
+            }]
+        }),
+        test({ // Import from different wildcard categories
+            code: "import { fn } from '@modules/apps/app1/features/app1Feature'",
+            filename: "@modules/apps/app2/features/app2Feature/MyFeature.tsx",
+            options,
+            errors: [{
+                message: "HTG: Importing from forbidden module category: /src/modules/apps/app2/features -> /src/modules/apps/app1/features.",
                 type: "Literal"
             }]
         })

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -7,7 +7,8 @@ describe('createUtils', function () {
     beforeEach(() => {
         utils = createUtils('/root', {
                 path: {
-                    '@modules/': 'src/modules/'
+                    '@modules/': 'src/modules/',
+                    '@absoluteModules/': '/home/Projects/project1/src/modules/'
                 },
                 modules: [
                     '@modules/libs',
@@ -23,6 +24,12 @@ describe('createUtils', function () {
             const result = utils.resolveFullPath('@modules/libs/module/file.js');
 
             assert.strictEqual(result, '/root/src/modules/libs/module/file.js');
+        });
+
+        it('should resolve aliased absolute path', function () {
+            const result = utils.resolveFullPath('@absoluteModules/libs/module/file.js');
+
+            assert.strictEqual(result, '/home/Projects/project1/src/modules/libs/module/file.js');
         });
 
         it('should resolve regular file path', function () {

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -91,7 +91,8 @@ describe('createUtils', function () {
             assert.deepStrictEqual(result, {
                 raw: '@modules/apps/demo/pages/page1/file.js',
                 realPath: '/root/src/modules/apps/demo/pages/page1/file.js',
-                path: '/root/src/modules/apps/*/pages/page1/file.js'
+                path: '/root/src/modules/apps/*/pages/page1/file.js',
+                wildcard: 'demo'
             });
         });
     });


### PR DESCRIPTION
This PR makes the following changes:
- Add documentation for wildcard imports
- Make imports between different apps forbidden
- Fix a bug where global alias paths were not resolved correctly

Internal changes:
- Expose matched wildcard in path resolver