### PR TITLE
Allow wildcard paths

### DIFF
--- a/lib/rules/enforce-hierarchy.js
+++ b/lib/rules/enforce-hierarchy.js
@@ -27,6 +27,24 @@ module.exports = {
                 },
                 additionalProperties: false,
             },
+            {
+                type: 'object',
+                patternProperties: {
+                    allowedWildcardPaths: {
+                        type: 'object',
+                        patternProperties: {
+                            '^.*$': {
+                                type: 'array',
+                                items: {
+                                    type: 'string'
+                                }
+                            }
+                        },
+                        additionalProperties: false,
+                    }
+                },
+                additionalProperties: false,
+            },
         ]
     },
 
@@ -34,17 +52,36 @@ module.exports = {
         const {resolveFullPath, resolve, resolveFromFullPath, stripCwd, findCategory} = createUtils(context.getCwd(), context.settings.htg);
 
         const options = context.options[0];
+        const { allowedWildcardPaths = {} } = context.options[1] || {};
 
         //----------------------------------------------------------------------
         // Helpers
         //----------------------------------------------------------------------
 
-        const resolvedOptions = Object.keys(options).reduce((previousValue, currentValue) => {
-            previousValue[resolveFullPath(currentValue)] = options[currentValue].map(value => resolveFullPath(value));
+        const resolveMapping = (mapping) => Object.keys(mapping).reduce((previousValue, currentValue) => {
+            previousValue[resolveFullPath(currentValue)] = mapping[currentValue].map(value => resolveFullPath(value));
             return previousValue;
         }, {});
 
+        const resolvedOptions = resolveMapping(options);
+        const resolvedAllowedWildcardPaths = resolveMapping(allowedWildcardPaths);
+
         const isDependencyAllowed = (source, target) => resolvedOptions[source].find(value => target.startsWith(value));
+
+        const isWildcardDependencyAllowed = (source, target) => {
+            const sourcePaths = Object.keys(resolvedAllowedWildcardPaths);
+
+            for (const sourcePath of sourcePaths) {
+                if (!source.startsWith(sourcePath)) continue;
+
+                const targetPaths = resolvedAllowedWildcardPaths[sourcePath];
+
+                for (const targetPath of targetPaths) {
+                    if (target.startsWith(targetPath)) return true;
+                }
+            }
+            return false;
+        };
 
         //----------------------------------------------------------------------
         // Public
@@ -64,8 +101,9 @@ module.exports = {
                 const sourceCategory = findCategory(source);
                 if (!sourceCategory) return;
 
-                if (sourceCategory !== targetCategory || source.wildcard === target.wildcard) {
-                    if (isDependencyAllowed(sourceCategory, targetCategory)) return;
+                if (isDependencyAllowed(sourceCategory, targetCategory)) {
+                    if (!target.wildcard) return;
+                    if (isWildcardDependencyAllowed(source.realPath, target.realPath)) return;
                 }
 
                 context.report({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-htg",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "HTG eslint plugin",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/enforce-hierarchy.js
+++ b/tests/lib/rules/enforce-hierarchy.js
@@ -63,6 +63,15 @@ ruleTester.run("enforce-hierarchy", rule, {
             code: "import { fn } from 'src/another/custom/folder/file'",
             filename: "src/custom/folder/file.ts",
             options,
+        }),
+        test({ // Import from allowed wildcard path
+            code: "import { fn } from '@modules/apps/app1/features/app1Feature'",
+            filename: "@modules/apps/app2/features/app2Feature/MyFeature.tsx",
+            options: [options[0], {
+                allowedWildcardPaths: {
+                    '@modules/apps/app2': ['@modules/apps/app1']
+                }
+            }],
         })
     ],
 


### PR DESCRIPTION
Allow to define specific paths which overrides wildcard path rules.

```js
{
    allowedWildcardPaths: {
        '@modules/apps/app2': ['@modules/apps/app1']
    }
}
```